### PR TITLE
Adding fully-qualified names to published files

### DIFF
--- a/pyblish_magenta/api.py
+++ b/pyblish_magenta/api.py
@@ -3,11 +3,13 @@ from .lib import (
     register_plugins,
     deregister_plugins,
     find_next_version,
+    format_version,
 )
 
 __all__ = [
     "setup",
     "register_plugins",
     "deregister_plugins",
-    "find_next_version"
+    "find_next_version",
+    "format_version",
 ]

--- a/pyblish_magenta/lib.py
+++ b/pyblish_magenta/lib.py
@@ -47,8 +47,23 @@ def find_next_version(versions):
 
     return highest_version + 1
 
-PLUGINS_PATH = os.path.dirname(plugins.__file__)
-PLUGIN_PATHS = [PLUGINS_PATH]
+
+def format_version(version):
+    """Format an integer to a version for filenames
+
+    Example:
+        >>> format_version(12)
+        'v012'
+        >>> format_version(650)
+        'v650'
+
+    Arguments:
+        version (int): Number to format
+
+    """
+
+    return "v%03d" % version
+
 
 for subdir in ("collectors", "extractors", "validators", "integrators"):
     PLUGIN_PATHS.append(os.path.join(PLUGINS_PATH, subdir))


### PR DESCRIPTION
This update is about adding more metadata to filenames, and what I think is a consistent solution.

``` bash
# Directories fully qualify the asset up till this point,
# where `ben01` is the name of the instance
\thedeal\film\seq01\1000\animation\publish\v036\pointcache\ben01

# The filename then embeds the same information
thedeal_seq01_1000_animation_ben01_v036.abc

# Full path:
\thedeal\film\seq01\1000\animation\publish\v036\pointcache\ben01\thedeal_seq01_1000_animation_ben01_v036.abc
```
