### PR TITLE
Update Selected References

### DIFF
--- a/pyblish_magenta/plugins/collect_pointcache.py
+++ b/pyblish_magenta/plugins/collect_pointcache.py
@@ -48,7 +48,7 @@ class CollectPointcache(pyblish.api.Collector):
             instance.set_data("endFrame", end_frame)
 
             # Don't publish by default, unless you're animating
-            if os.environ["TASK"] != "animation":
+            if os.environ["TOPICS"].split()[-1] != "animation":
                 instance.set_data("publish", False)
 
             self.log.info("Successfully collected %s" % name)

--- a/pyblish_magenta/utils/maya/versioning.py
+++ b/pyblish_magenta/utils/maya/versioning.py
@@ -4,7 +4,13 @@ from maya import cmds
 
 
 def update_reference(reference):
-    """Update reference to the latest version"""
+    """Update reference to the latest version
+
+    Arguments:
+        reference (str): Name of reference node
+
+    """
+
     filename = cmds.referenceQuery(reference, filename=True)
 
     # NOTE(marcus): This should be based on something more
@@ -33,3 +39,15 @@ def update_reference(reference):
         cmds.file(new_filename, loadReference=reference)
     else:
         print("\"%s\" already up to date" % reference)
+
+
+def update_selected_references():
+    """Convenience method of :func:`update_reference`
+
+    Usage:
+        Select reference node, and run this function.
+
+    """
+
+    for reference in cmds.ls(selection=True, type="reference"):
+        update_reference(reference)


### PR DESCRIPTION
Taking advantage of how assets are published, we can now to automatic updates to the latest of versions with a single click.

![untitled](https://cloud.githubusercontent.com/assets/2152766/9358717/677fe77e-4685-11e5-8228-a6802c294b05.gif)

Still needs to be made more generic, but the concept and workflow is sound.
