### PR TITLE
Transposing version number in hierarchy

### DIFF
--- a/pyblish_magenta/plugins/extract_comment.py
+++ b/pyblish_magenta/plugins/extract_comment.py
@@ -1,5 +1,5 @@
 import os
-import pyblish_magenta.plugin
+import pyblish_magenta.api
 
 
 class ExtractComment(pyblish_magenta.api.Extractor):

--- a/pyblish_magenta/plugins/integrate_assets.py
+++ b/pyblish_magenta/plugins/integrate_assets.py
@@ -11,62 +11,65 @@ class IntegrateAssets(pyblish.api.Integrator):
 
     label = "Assets"
 
-    def process(self, context):
+    def process(self, context, instance):
         self.log.debug("Source file: %s" % context.data("currentFile"))
 
         current_file = context.data("currentFile").replace("\\", "/")
         publish_dir = self.compute_publish_directory(current_file)
+        versions_dir = os.path.join(publish_dir,
+                                    instance.data("family"),
+                                    instance.data("name"))
 
+        # Compute next version for this instance
         try:
-            existing_versions = os.listdir(publish_dir)
+            existing_versions = os.listdir(versions_dir)
             version = pyblish_magenta.api.find_next_version(existing_versions)
         except OSError:
             version = 1
 
-        version_dir = os.path.join(
-            publish_dir, pyblish_magenta.api.format_version(version))
+        version = pyblish_magenta.api.format_version(version)
+
+        version_dir = "{versions}/{version}".format(
+            versions=versions_dir,
+            version=version)
 
         # Copy files/directories from the temporary
         # extraction directory to the integration directory.
-        for instance in context:
-            extract_dir = instance.data("extractDir")
+        extract_dir = instance.data("extractDir")
 
-            if not extract_dir:
-                self.log.debug("Skipping %s; no files found" % instance)
-                continue
+        if not extract_dir:
+            return self.log.debug("Skipping %s; no files found" % instance)
 
-            for fname in os.listdir(extract_dir):
-                src = os.path.join(extract_dir, fname)
-                dst = "{root}/{family}/{instance}".format(
-                    root=version_dir,
-                    family=instance.data("family"),
-                    instance=instance.data("name")).replace("/", os.sep)
+        for fname in os.listdir(extract_dir):
+            src = os.path.join(extract_dir, fname)
+            dst = version_dir
 
-                # Store reference for other integrators
-                instance.set_data("integrationDir", dst)
+            if os.path.isfile(src):
+                try:
+                    os.makedirs(dst)
+                except OSError:
+                    pass
 
-                msg = "Copying %s \"%s\" to \"%s\""
-                if os.path.isfile(src):
-                    # Assembly fully-qualified name
-                    # E.g. thedeal_seq01_1000_animation_ben01_v002
+                # Assembly fully-qualified name
+                # E.g. thedeal_seq01_1000_animation_ben01_v002.ma
+                _, ext = os.path.splitext(fname)
+                filename = "{topic}_{version}_{instance}".format(
+                    topic="_".join(os.environ["TOPICS"].split()),
+                    instance=instance.data("name"),
+                    version=version) + ext
 
-                    if not os.path.exists(dst):
-                        os.makedirs(dst)
+                dst = os.path.join(dst, filename)
+                self.log.info("Copying file \"%s\" to \"%s\"" % (src, dst))
+                shutil.copy(src, dst)
 
-                    filename = "{topic}_{version}_{instance}".format(
-                        topic="_".join(os.environ["TOPICS"].split()),
-                        instance=instance.data("name"),
-                        version=pyblish_magenta.api.format_version(version))
+            else:
+                dst = os.path.join(dst, fname)
+                self.log.info("Copying directory \"%s\" to \"%s\""
+                              % (src, dst))
+                shutil.copytree(src, dst)
 
-                    _, ext = os.path.splitext(fname)
-                    dst = os.path.join(dst, filename + ext)
-                    self.log.info(msg % ("file", src, dst))
-                    shutil.copy(src, dst)
-
-                else:
-                    dst = os.path.join(dst, fname)
-                    self.log.info(msg % ("directory", src, dst))
-                    shutil.copytree(src, dst)
+        # Store reference for further integration
+        instance.set_data("integrationDir", version_dir)
 
         self.log.info("Integrated to directory \"{0}\"".format(version_dir))
 


### PR DESCRIPTION
This is in regards to the Publishing for lighting conversation here:
- http://forums.pyblish.com/t/publishing-renders-lighting/149/10

Basically, moving the version number under the `Instance`, as opposed to having the `Instance` under a version, allowing for individual versioning of instances, at the cost of not being able to link versions together anymore.

``` bash
# Before
publish
▾ v001
  ▾ familyName
    ▾ instanceName
      ▸ content

# After
publish
▾ familyName
  ▾ instanceName
    ▾ v001
      ▸ content
```

We'll have to find a new way of linking versions together, for example, keeping track of which instance a particular playblast belongs to.
